### PR TITLE
Fix masking collection elements

### DIFF
--- a/test/index_test.js
+++ b/test/index_test.js
@@ -58,6 +58,34 @@ describe('.validate()', () => {
       });
     });
 
+    it('should mask collections', () => {
+      const data = [{
+        bar: ['biz'],
+        baz: [{
+          bez: 'buz',
+          qux: 'qix'
+        }],
+        foo: 'baz',
+        qox: 'qux'
+      }];
+
+      const constraint = is.collection({
+        bar: is.collection(is.notBlank()),
+        baz: is.collection({
+          bez: is.notBlank()
+        }),
+        foo: is.required()
+      });
+
+      expect(validate(data, constraint)).toEqual([{
+        bar: ['biz'],
+        baz: [{
+          bez: 'buz'
+        }],
+        foo: 'baz'
+      }]);
+    });
+
     it('should return `true` if `mask` option is given as `false`', () => {
       expect(validate({ foo: {} }, { foo: is.required() }, { mask: false })).toBe(true);
     });


### PR DESCRIPTION
This PR adds support for masking elements of arrays that are being validated with a set of constraints. Since these are expected to be objects they should be masked as well.