### PR TITLE
Add deepRequired option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,8 @@ function maskDataFromConstraints(data, constraints) {
 export default ValidationFailedError => {
   const validator = new Validator();
 
-  return (data, constraints, { groups, mask = true, throws = true } = {}) => {
-    const constraint = constraints instanceof Assert ? constraints : new Constraint(constraints, { deepRequired: true });
+  return (data, constraints, { deepRequired = true, groups, mask = true, throws = true } = {}) => {
+    const constraint = constraints instanceof Assert ? constraints : new Constraint(constraints, { deepRequired });
     const errors = validator.validate(data, constraint, groups);
 
     if (errors === true) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -28,6 +28,10 @@ describe('.validate()', () => {
       expect(errors.foo.show().assert).toBe('HaveProperty');
     });
 
+    it('should not validate given `constraint` with `deepRequired` option if provided as `false`', () => {
+      expect(validate({}, { foo: { bar: is.required() } }, { deepRequired: false })).toEqual({});
+    });
+
     it('should returned given `data` masked with given `constraint` keys', () => {
       const data = {
         bar: {


### PR DESCRIPTION
This PR adds the `deepRequired` option, allowing to override its default `true` value and not validate nested object required asserts strictly.